### PR TITLE
Fix bug where Google Calendar Event location is `nil`

### DIFF
--- a/lib/google/apis/calendar_v3/event.rb
+++ b/lib/google/apis/calendar_v3/event.rb
@@ -8,7 +8,7 @@ module Google
         include ActionView::Helpers::DateHelper
 
         def meeting_url
-          matches = (location + description).match(MEETING_URL_REGEX)
+          matches = (location.to_s + description.to_s).match(MEETING_URL_REGEX)
           matches[0] if matches
         end
 


### PR DESCRIPTION
Fixes the following stacktrace:

```text
/Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/zoom_launcher-0.1.1/lib/google/apis/calendar_v3/event.rb:11:in `+': no implicit conversion of nil into String (TypeError)
	from /Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/zoom_launcher-0.1.1/lib/google/apis/calendar_v3/event.rb:11:in `meeting_url'
	from /Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/zoom_launcher-0.1.1/lib/zoom_launcher/cli.rb:18:in `launch'
	from /Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/parkr/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/zoom_launcher-0.1.1/bin/zoom:7:in `<top (required)>'
	from /Users/parkr/.rbenv/versions/2.4.1/bin/zoom:22:in `load'
	from /Users/parkr/.rbenv/versions/2.4.1/bin/zoom:22:in `<main>'
```

/cc @benbalter 