### PR TITLE
Handle duplicated Zoom URLs

### DIFF
--- a/lib/google/apis/calendar_v3/event.rb
+++ b/lib/google/apis/calendar_v3/event.rb
@@ -4,7 +4,7 @@ module Google
   module Apis
     module CalendarV3
       class Event
-        MEETING_URL_REGEX = %r{https://.*\.zoom\.us/j/\d+}
+        MEETING_URL_REGEX = %r{https://.*?\.zoom\.us/j/\d+}
         include ActionView::Helpers::DateHelper
 
         def meeting_url


### PR DESCRIPTION
On our team, we put the Zoom URL in both the location _and_ the description. The greedy `.*` operator was consuming both and attempting to launch a bad URL:

```
$ bundle exec bin/zoom 
/usr/local/var/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/signet-0.7.3/lib/signet/oauth_2/client.rb:1180: warning: constant ::Fixnum is deprecated
Your next Zoom meeting is "Atom Sub-Team Sync".
It is scheduled to start in 2 days.

Here's the Zoom URL: https://github.zoom.us/j/254713128https://github.zoom.us/j/254713128
Oh, and here's the URL in case you need it: https://www.google.com/calendar/event?eid=cXNrZWQ2MzMyYmQyZ3NiMmFkYmY5cGJyODRfMjAxNzA2MTZUMTczMDAwWiBzbWFzaHdpbHNvbkBnaXRodWIuY29t
```

I've fixed it by using a lazy operator for the Zoom subdomain.