### PR TITLE
Parse vanity URLs

### DIFF
--- a/lib/google/apis/calendar_v3/event.rb
+++ b/lib/google/apis/calendar_v3/event.rb
@@ -4,11 +4,11 @@ module Google
   module Apis
     module CalendarV3
       class Event
-        MEETING_URL_REGEX = %r{https://.*?\.zoom\.us/j/\d+}
+        MEETING_URL_REGEX = %r{https://.*?\.zoom\.us/(?:j/\d+|my/\S+)}
         include ActionView::Helpers::DateHelper
 
         def meeting_url
-          matches = (location.to_s + description.to_s).match(MEETING_URL_REGEX)
+          matches = "#{location} #{description}".match(MEETING_URL_REGEX)
           matches[0] if matches
         end
 

--- a/spec/fixtures/vanity.json
+++ b/spec/fixtures/vanity.json
@@ -1,0 +1,56 @@
+{
+ "kind": "calendar#events",
+ "etag": "\"abc123\"",
+ "summary": "Personal",
+ "updated": "2017-03-21T17:29:36.593Z",
+ "timeZone": "America/New_York",
+ "accessRole": "owner",
+ "defaultReminders": [
+  {
+   "method": "popup",
+   "minutes": 10
+  }
+ ],
+ "nextSyncToken": "xxx=",
+ "items": [
+  {
+   "kind": "calendar#event",
+   "etag": "\"1234\"",
+   "id": "1234abc",
+   "status": "confirmed",
+   "htmlLink": "https://www.google.com/calendar/event?eid=1234",
+   "created": "2017-01-24T19:22:33.000Z",
+   "updated": "2017-01-28T11:43:45.502Z",
+   "summary": "Test Event",
+   "description": "This is a test event",
+   "location": "https://foo.zoom.us/my/fancyroom",
+   "creator": {
+    "email": "joe@example.com",
+    "displayName": "Joe Example"
+   },
+   "organizer": {
+     "email": "foo@example.com",
+     "displayName": "Joe Example"
+   },
+   "start": {
+    "dateTime": "2016-01-01T18:00:00-05:00"
+   },
+   "end": {
+    "dateTime": "2016-01-25T19:30:00-05:00"
+   },
+   "iCalUID": "abc@google.com",
+   "sequence": 0,
+   "attendees": [
+    {
+     "email": "joe@example.com",
+     "displayName": "Joe Example",
+     "organizer": true,
+     "responseStatus": "accepted"
+    }
+   ],
+   "reminders": {
+    "useDefault": true
+   }
+  }
+ ]
+}

--- a/spec/zoom_launcher/cli_spec.rb
+++ b/spec/zoom_launcher/cli_spec.rb
@@ -14,29 +14,44 @@ RSpec.describe ZoomLauncher::CLI do
     }
   end
 
-  before do
-    url = api_base + args.map { |k, v| "#{k}=#{v}" }.join('&')
-    body = fixture_contents('events.json')
-    stub_request(:get, url).to_return(status: 200, body: body, headers: headers)
+  describe 'normal room URLs' do
+    before do
+      url = api_base + args.map { |k, v| "#{k}=#{v}" }.join('&')
+      body = fixture_contents('events.json')
+      stub_request(:get, url).to_return(status: 200, body: body, headers: headers)
+    end
+
+    it 'creates the calendar' do
+      expect(subject.calendar).to be_a(Google::Apis::CalendarV3::CalendarService)
+    end
+
+    it 'pulls events' do
+      expect(subject.events.kind).to eql('calendar#events')
+      items = subject.events.items
+      expect(items.count).to eql(1)
+      expect(items.first.location).to eql('https://foo.zoom.us/j/1245678')
+    end
+
+    it 'pulls the next event' do
+      expect(subject.next_event.location).to eql('https://foo.zoom.us/j/1245678')
+    end
+
+    it 'launches' do
+      expect(output).to include("Your next Zoom meeting is \"\e[1mTest Event\e[0m\"")
+      expect(output).to include("Here's the Zoom URL: \e[1mhttps://foo.zoom.us/j/1245678\e[0m")
+    end
   end
 
-  it 'creates the calendar' do
-    expect(subject.calendar).to be_a(Google::Apis::CalendarV3::CalendarService)
-  end
+  describe 'vanity room URLs' do
+    before do
+      url = api_base + args.map { |k, v| "#{k}=#{v}" }.join('&')
+      body = fixture_contents('vanity.json')
+      stub_request(:get, url).to_return(status: 200, body: body, headers: headers)
+    end
 
-  it 'pulls events' do
-    expect(subject.events.kind).to eql('calendar#events')
-    items = subject.events.items
-    expect(items.count).to eql(1)
-    expect(items.first.location).to eql('https://foo.zoom.us/j/1245678')
-  end
-
-  it 'pulls the next event' do
-    expect(subject.next_event.location).to eql('https://foo.zoom.us/j/1245678')
-  end
-
-  it 'launches' do
-    expect(output).to include("Your next Zoom meeting is \"\e[1mTest Event\e[0m\"")
-    expect(output).to include("Here's the Zoom URL: \e[1mhttps://foo.zoom.us/j/1245678\e[0m")
+    it 'parses the event URL' do
+      expect(subject.next_event.location).to eql('https://foo.zoom.us/my/fancyroom')
+      expect(output).to include("Here's the Zoom URL: \e[1mhttps://foo.zoom.us/my/fancyroom\e[0m")
+    end
   end
 end

--- a/zoom_launcher.gemspec
+++ b/zoom_launcher.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['ben.balter@github.com']
 
   spec.summary       = 'A command line tool for joining your next Zoom meeting'
-  spec.homepage      = "https://github.com/benbalter/zoom-launcher"
+  spec.homepage      = 'https://github.com/benbalter/zoom-launcher'
   spec.license       = 'MIT'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Parse vanity `https://foo.zoom.us/my/...`-style URLs. Now with tests!

Fixes #1.